### PR TITLE
Homepage/bug-report address updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,12 +17,9 @@ remote server, and work from that.
    on how to start using sitecopy.
  * For information on the OS/2 port, see 'README.emx'
  * For information on the GNOME interface, see 'README.gnome'
- * Send bug reports, feature requests etc to <sitecopy@lists.manyfish.co.uk>
- * Web site at http://www.manyfish.co.uk/sitecopy/
- * Discussion list: subscribe by mail to
-      <sitecopy-request@lists.manyfish.co.uk>, or
-   via the Web at http://www.manyfish.co.uk/mailman/listinfo/sitecopy/
-
+ * Web site at https://www.manyfish.co.uk/sitecopy/
+ * Github repository: https://github.com/notroj/sitecopy/
+   
 sitecopy is:
    Copyright (C) 1998-2005 Joe Orton
 The GNOME frontend is:

--- a/configure.in
+++ b/configure.in
@@ -24,7 +24,7 @@ dnl Extract the version (sans LF) from .version, created at release-time.
 m4_define(sc_version, m4_translit(m4_include(.version), [
 ]))
 
-AC_INIT([sitecopy], [sc_version], [sitecopy@lyra.org])
+AC_INIT([sitecopy], [sc_version], [https://github.com/notroj/sitecopy],,[https://www.manyfish.uk/sitecopy/])
 
 AC_CONFIG_SRCDIR(src/sites.c)
 AC_CONFIG_HEADER(config.h)

--- a/src/console_fe.c
+++ b/src/console_fe.c
@@ -1374,7 +1374,7 @@ static void usage(void)
 "  -u, --update          Update the remote site\n"
 "  -h, --help            Display this help message\n"
 "  -V, --version         Display version information\n"
-"Please send feature requests and bug reports to sitecopy@lyra.org\n"));
+"Please send feature requests and bug reports via %s\n"), PACKAGE_BUGREPORT);
 }
 
 


### PR DESCRIPTION
```
* src/console_fe.c (usage): Use PACKAGE_BUGREPORT as reporting
  address.

* configure.in: Update homepage/bugreport addresses.

* README.md: Renamed from README.
```